### PR TITLE
Auto property definition alongside `[DynamoDbIgnore]`

### DIFF
--- a/src/EfficientDynamoDb/Attributes/DynamoDbAutoPropertyAttribute.cs
+++ b/src/EfficientDynamoDb/Attributes/DynamoDbAutoPropertyAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EfficientDynamoDb.Attributes
+{
+    /// <summary>
+    /// Marks a class (or interface) that all properties from it, and it's derivates should be
+    /// automatically mapped to DynamoDb attributes, that means all child properties except those
+    /// marked with <see cref="DynamoDbIgnoreAttribute"/>. 
+    /// </summary>
+    /// <remarks>
+    /// Even if the property is not defined in the class or the interface, but it's defined on a child class that
+    /// implements it will be automatically mapped to DynamoDb attribute
+    /// unless they are explicitly marked to be ignored with <see cref="DynamoDbIgnoreAttribute"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class)]
+    public sealed class DynamoDbAutoPropertyAttribute : Attribute
+    {
+    }
+}

--- a/src/EfficientDynamoDb/Attributes/DynamoDbIgnoreAttribute.cs
+++ b/src/EfficientDynamoDb/Attributes/DynamoDbIgnoreAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EfficientDynamoDb.Attributes
+{
+    /// <summary>
+    /// When used on a class that is marked with <see cref="DynamoDbAutoPropertyAttribute"/>
+    /// it will ignore the property from being mapped to DynamoDb attribute automatically.
+    /// </summary>
+    /// <remarks>
+    /// Even if a parent property is marked with <see cref="DynamoDbIgnoreAttribute"/>,
+    /// you can still override it in a child class with <see cref="DynamoDbPropertyAttribute"/>, as you are explicitly
+    /// requesting to map it to DynamoDb attribute.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class DynamoDbIgnoreAttribute : Attribute
+    {
+        
+    }
+}

--- a/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
+++ b/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
@@ -76,11 +76,12 @@ namespace EfficientDynamoDb.Internal.Metadata
                     var typeInterfaces = type.GetInterfaces().ToHashSet();
                     var baseTypes = GetBaseTypes(type).ToHashSet();
                     
-                    TableName ??= typeInterfaces.Select(x => x.GetCustomAttribute<DynamoDbTableAttribute>()?.TableName).FirstOrDefault(x => x != null) ?? 
+                    TableName ??= type.GetCustomAttribute<DynamoDbTableAttribute>()?.TableName ??
+                                  typeInterfaces.Select(x => x.GetCustomAttribute<DynamoDbTableAttribute>()?.TableName).FirstOrDefault(x => x != null) ?? 
                                   baseTypes.Select(x => x.GetCustomAttribute<DynamoDbTableAttribute>()?.TableName).FirstOrDefault(x => x != null);
 
                     // Check if any of the interfaces has DynamoDbAutoPropertyAttribute
-                    var autoProperty = 
+                    var autoProperty = type.GetCustomAttribute<DynamoDbAutoPropertyAttribute>() != null ||
                         baseTypes.Any(x => x.GetCustomAttribute<DynamoDbAutoPropertyAttribute>() != null) ||
                         typeInterfaces.Any(x => x.GetCustomAttribute<DynamoDbAutoPropertyAttribute>() != null);
             
@@ -91,7 +92,7 @@ namespace EfficientDynamoDb.Internal.Metadata
                         .ToHashSet();
                     
                     var propList = 
-                        baseTypes.SelectMany(x => x.GetProperties(BindingFlags));
+                        type.GetProperties(BindingFlags).Concat(baseTypes.SelectMany(x => x.GetProperties(BindingFlags)));
 
                     var allProps = propList.Concat(type.GetProperties(BindingFlags));
 

--- a/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
+++ b/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
@@ -53,6 +53,7 @@ namespace EfficientDynamoDb.Internal.Metadata
             ClassType = ConverterBase.ClassType;
             var typeInterfaces = new Stack<Type>(type.GetInterfaces());
 
+            // Check if any of the interfaces has DynamoDbAutoPropertyAttribute
             var autoProperty = typeInterfaces.Any(x => x.GetCustomAttribute<DynamoDbAutoPropertyAttribute>() != null);
             
             // We store explicitly ignored properties to avoid adding them implicitly via auto property
@@ -71,6 +72,11 @@ namespace EfficientDynamoDb.Internal.Metadata
                             continue;
                         
                         currentType ??= typeInterfaces.Pop();
+                        
+                        // If auto property is not set, check if the current type has DynamoDbAutoPropertyAttribute
+                        if(!autoProperty)
+                            autoProperty = currentType.GetCustomAttribute<DynamoDbAutoPropertyAttribute>() != null;
+                        
                         const BindingFlags bindingFlags =
                             BindingFlags.Instance |
                             BindingFlags.Public |


### PR DESCRIPTION
As I mentioned on https://github.com/AllocZero/EfficientDynamoDb/discussions/238, under `Attribute Annotation Requirements in EfficientDynamoDb`, this PR should allow basically a more seamless experience. It will automatically map properties that are derivates of the class that has the attribute. 


This PR introduces two new attribute classes as part of our push for improving DynamoDb utilization: `DynamoDbAutoPropertyAttribute` and `DynamoDbIgnoreAttribute`.

## Key Changes 

### Introduction of `DynamoDbAutoPropertyAttribute`
This attribute allows automatic mapping of the properties from a class or interface to DynamoDb attributes. It includes:
* Properties of the parent class
* Properties of the derived classes
* Properties of the implemented interfaces

The properties are marked to be automatically mapped to DynamoDb attributes unless they are explicitly ignored.

```csharp
namespace EfficientDynamoDb.Attributes
{
    [DynamoDbAutoProperty]
    public sealed class SampleEntity
    {
        public string AutoProp1 { get; set; }
        public int AutoProp2 { get; set; }
    }
} 
```
Is equivalent to
```csharp
namespace EfficientDynamoDb.Attributes
{
    public sealed class SampleEntity
    {
        [DynamoDbProperty("AutoProp1")]
        public string AutoProp1 { get; set; }
        
        [DynamoDbProperty("AutoProp2")]
        public int AutoProp2 { get; set; }
    }
} 
```
With `DynamoDbAutoPropertyAttribute`, the properties are automatically treated as DynamoDb attributes

### Introduction of `DynamoDbIgnoreAttribute`
This attribute can be used to mark unwanted properties, preventing them from being automatically mapped to DynamoDb attributes, even in classes carrying the `DynamoDbAutoPropertyAttribute`.

```csharp
namespace EfficientDynamoDb.Attributes
{
    [DynamoDbAutoProperty]
    public sealed class SampleEntityIgnore
    {
       public string AutoProp1 { get; set; }
       
       [DynamoDbIgnore]
       public int AutoProp2 { get; set; }
    }
}
```
Is equivalent to
```csharp
namespace EfficientDynamoDb.Attributes
{
    public sealed class SampleEntityIgnore
    {
       [DynamoDbProperty("AutoProp1")]
       public string AutoProp1 { get; set; }
       
       // Note no attribute, it won't be mapped
       public int AutoProp2 { get; set; }
    }
}
```
In the example above, `AutoProp1` is automatically mapped to a DynamoDb attribute, while `AutoProp2` is ignored.

### The Precedence of DynamoDbPropertyAttribute over DynamoDbIgnoreAttribute

In the event that a property is marked using both the `DynamoDbIgnoreAttribute` and `DynamoDbPropertyAttribute`, the explicit nature of `DynamoDbPropertyAttribute` takes precedence. This allows an overriding feature, whereby a specific property, despite being explicitly ignored (e.g., at the interface), can still be stored if it's explicitly required using `DynamoDbPropertyAttribute` at the derived class level.

This feature allows more flexibility in dealing with attributes on both parent and child classes or interfaces. By specifying `DynamoDbPropertyAttribute` on a property, that property will be included in the mapping process to DynamoDb attributes, bypassing the `DynamoDbIgnoreAttribute`.

```csharp
namespace EfficientDynamoDb.Attributes
{
    [DynamoDbAutoProperty]
    public interface SampleInterface
    {
       [DynamoDbIgnore]
       int InterfaceProp1 { get; set; }
       
       string InterfaceProp2 { get; set; }
       
       double InterfaceProp3 { get; set; }
    }
    
    public sealed class SampleEntity : SampleInterface
    {
       [DynamoDbProperty("InterfaceProp1")]
       public int InterfaceProp1 { get; set; }
       
       public string InterfaceProp2 { get; set; }
       
       [DynamoDbIgnore]
       public double InterfaceProp3 { get; set; }
    }
}
```


* `InterfaceProp1` is **MAPPED** and this is why: 
  * Even though it is ignored in the `SampleInterface` interface using `DynamoDbIgnoreAttribute`, it is explicitly marked for mapping to DynamoDb in the `SampleEntity` using `DynamoDbPropertyAttribute`, which takes presedence.
 
* `InterfaceProp2` is **MAPPED** and this is why: 
  * Due to the interface having `DynamoDbAutoProperty` and no explicit ignore is defined, it is naturally mapped to DynamoDb.

* `InterfaceProp3` is **NOT MAPPED** and this is why: 
  * By being explicitly marked to be ignored in the `SampleEntity` using `DynamoDbIgnoreAttribute`, the `DynamoDbAutoProperty` from the interface (parent) doesn't have any effect. 